### PR TITLE
Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Prototype/*
+node_modules/


### PR DESCRIPTION
node_modules folder will not be added in the repo, instead use **npm install** in the root folder after cloning the project